### PR TITLE
fix "ImportError: cannot import name 'StrEnum' from 'enum'"

### DIFF
--- a/mace-openmm-full.yml
+++ b/mace-openmm-full.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
+  - python=3.11
   - pytorch=2.3.*
   - mdtraj
   - openmm


### PR DESCRIPTION
The StrEnum class was introduced in Python 3.11. StrEnum does not exist in the Python 3.10 environment.